### PR TITLE
Clone and validate repository configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,46 +14,5 @@ ENVIRONMENT = "production"
 NODE_ENV = "development"
 ENVIRONMENT = "preview"
 
-# Build configuration
-[build]
-command = "npm run build"
-cwd = "."
-
-# Headers configuration
-[[headers]]
-for = "/*"
-[headers.values]
-X-Frame-Options = "DENY"
-X-Content-Type-Options = "nosniff"
-Referrer-Policy = "strict-origin-when-cross-origin"
-Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
-
-[[headers]]
-for = "/api/*"
-[headers.values]
-Cache-Control = "public, max-age=0, s-maxage=86400"
-
-[[headers]]
-for = "/*.css"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-
-[[headers]]
-for = "/*.js"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-
-[[headers]]
-for = "/*.png"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-
-[[headers]]
-for = "/favicon*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-
-[[headers]]
-for = "/yousef-logo*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
+# Note: For Cloudflare Pages, custom headers should be defined in the built output (or project) as a `_headers` file.
+# The project already contains `public/_headers` which Pages will use.


### PR DESCRIPTION
Remove unsupported `[build]` and `[[headers]]` sections from `wrangler.toml` to fix Cloudflare Pages validation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ad530f6-39b3-4677-9d83-958ddfc0f497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ad530f6-39b3-4677-9d83-958ddfc0f497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

