### PR TITLE
Feat/android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable the Android release workflow to run on pull requests targeting master. This builds the APK and uploads it as an artifact so we can validate releases before merging.

<!-- End of auto-generated description by cubic. -->

