### PR TITLE
Feat/android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -3,10 +3,10 @@ name: Android Release
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Install dependencies (this step is cached as long as the dependencies don't change)
 COPY package.json pnpm-lock.yaml ./
 
-#RUN npm install -g corepack@latest
+RUN npm install -g corepack@latest
 
 #RUN corepack enable pnpm && pnpm install
 RUN corepack enable && pnpm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json pnpm-lock.yaml ./
 #RUN npm install -g corepack@latest
 
 #RUN corepack enable pnpm && pnpm install
-RUN npm install -g pnpm && pnpm install
+RUN corepack enable && pnpm install
 
 # Copy the rest of your app's source code
 COPY . .


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Aligns GitHub workflows to the main branch and fixes Docker builds by using Corepack for pnpm. Workflows now run as expected, and Docker images install dependencies reliably.

- **Bug Fixes**
  - Workflows: trigger on main instead of master in android-release.yml and ci.yaml.
  - Dockerfile: install and enable corepack, then run pnpm install to resolve pnpm install failures.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI and release workflows to run against the main branch.
  - Standardized container build environment by enabling Corepack and using pnpm via Corepack, improving consistency and reproducibility.
  - No changes to application features or behavior.

- Tests
  - Existing test steps remain unchanged.

- Documentation
  - No user-facing documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->