### PR TITLE
Configure ollama selfhosted LLM setup

### DIFF
--- a/app/components/@settings/tabs/providers/local/LocalProvidersTab.tsx
+++ b/app/components/@settings/tabs/providers/local/LocalProvidersTab.tsx
@@ -151,8 +151,11 @@ export default function LocalProvidersTab() {
   const fetchOllamaModels = async () => {
     try {
       setIsLoadingModels(true);
-
-      const response = await fetch('http://127.0.0.1:11434/api/tags');
+      const baseUrl =
+        (providers?.Ollama?.settings?.baseUrl as string | undefined) ||
+        (import.meta.env?.OLLAMA_API_BASE_URL as string | undefined) ||
+        OLLAMA_API_URL;
+      const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/tags`);
       const data = (await response.json()) as { models: OllamaModel[] };
 
       setOllamaModels(
@@ -170,7 +173,11 @@ export default function LocalProvidersTab() {
 
   const updateOllamaModel = async (modelName: string): Promise<boolean> => {
     try {
-      const response = await fetch(`${OLLAMA_API_URL}/api/pull`, {
+      const baseUrl =
+        (providers?.Ollama?.settings?.baseUrl as string | undefined) ||
+        (import.meta.env?.OLLAMA_API_BASE_URL as string | undefined) ||
+        OLLAMA_API_URL;
+      const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/pull`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: modelName }),
@@ -222,7 +229,7 @@ export default function LocalProvidersTab() {
         }
       }
 
-      const updatedResponse = await fetch('http://127.0.0.1:11434/api/tags');
+      const updatedResponse = await fetch(`${baseUrl.replace(/\/$/, '')}/api/tags`);
       const updatedData = (await updatedResponse.json()) as { models: OllamaModel[] };
       const updatedModel = updatedData.models.find((m) => m.name === modelName);
 
@@ -279,7 +286,11 @@ export default function LocalProvidersTab() {
 
   const handleDeleteOllamaModel = async (modelName: string) => {
     try {
-      const response = await fetch(`${OLLAMA_API_URL}/api/delete`, {
+      const baseUrl =
+        (providers?.Ollama?.settings?.baseUrl as string | undefined) ||
+        (import.meta.env?.OLLAMA_API_BASE_URL as string | undefined) ||
+        OLLAMA_API_URL;
+      const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/delete`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -32,6 +32,7 @@ import type { ElementInfo } from '~/components/workbench/Inspector';
 import type { TextUIPart, FileUIPart, Attachment } from '@ai-sdk/ui-utils';
 import { useMCPStore } from '~/lib/stores/mcp';
 import type { LlmErrorAlertType } from '~/types/actions';
+import type { ModelInfo } from '~/lib/modules/llm/types';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -141,7 +142,13 @@ export const ChatImpl = memo(
     const [llmErrorAlert, setLlmErrorAlert] = useState<LlmErrorAlertType | undefined>(undefined);
     const [model, setModel] = useState(() => {
       const savedModel = Cookies.get('selectedModel');
-      return savedModel || DEFAULT_MODEL;
+      if (savedModel) return savedModel;
+      const envProvider = (import.meta.env?.LLM_PROVIDER || '').toString().toLowerCase();
+      const envModel = (import.meta.env?.OLLAMA_MODEL || '').toString();
+      if (envProvider === 'ollama' && envModel) {
+        return envModel;
+      }
+      return DEFAULT_MODEL;
     });
     const [provider, setProvider] = useState<UIProviderInfo>(() => {
       const toUIProvider = (p: ProviderInfo): UIProviderInfo => ({
@@ -153,8 +160,16 @@ export const ChatImpl = memo(
         icon: p.icon,
       });
       const savedProvider = Cookies.get('selectedProvider');
-      const found = (PROVIDER_LIST.find((p) => p.name === savedProvider) || DEFAULT_PROVIDER) as ProviderInfo;
-
+      if (savedProvider) {
+        const foundSaved = (PROVIDER_LIST.find((p) => p.name === savedProvider) || DEFAULT_PROVIDER) as ProviderInfo;
+        return toUIProvider(foundSaved);
+      }
+      const envProvider = (import.meta.env?.LLM_PROVIDER || '').toString().toLowerCase();
+      if (envProvider) {
+        const foundEnv = (PROVIDER_LIST.find((p) => p.name.toLowerCase() === envProvider) || DEFAULT_PROVIDER) as ProviderInfo;
+        return toUIProvider(foundEnv);
+      }
+      const found = DEFAULT_PROVIDER as ProviderInfo;
       return toUIProvider(found);
     });
     const { showChat } = useStore(chatStore);
@@ -163,6 +178,8 @@ export const ChatImpl = memo(
     const [chatMode, setChatMode] = useState<'discuss' | 'build'>('build');
     const [selectedElement, setSelectedElement] = useState<ElementInfo | null>(null);
     const mcpSettings = useMCPStore((state) => state.settings);
+    const [modelList, setModelList] = useState<ModelInfo[]>([]);
+    const [isModelLoading, setIsModelLoading] = useState<'all' | 'Ollama' | undefined>(undefined);
 
     const {
       messages,
@@ -624,12 +641,50 @@ export const ChatImpl = memo(
     );
 
     useEffect(() => {
-      const storedApiKeys = Cookies.get('apiKeys');
+      if (typeof window !== 'undefined') {
+        let parsedApiKeys: Record<string, string> | undefined = {};
 
-      if (storedApiKeys) {
-        setApiKeys(JSON.parse(storedApiKeys));
+        try {
+          parsedApiKeys = getApiKeysFromCookies();
+          setApiKeys(parsedApiKeys);
+        } catch (error) {
+          console.error('Error loading API keys from cookies:', error);
+          Cookies.remove('apiKeys');
+        }
+
+        setIsModelLoading('all');
+        fetch('/api/models')
+          .then((response) => response.json())
+          .then((data) => {
+            const typedData = data as { modelList: ModelInfo[] };
+            setModelList(typedData.modelList);
+          })
+          .catch((error) => {
+            console.error('Error fetching model list:', error);
+          })
+          .finally(() => {
+            setIsModelLoading(undefined);
+          });
+
+        // If env prefers Ollama and base URL is set, force-load Ollama models list once
+        const envProvider = (import.meta.env?.LLM_PROVIDER || '').toString().toLowerCase();
+        const ollamaBase = (import.meta.env?.OLLAMA_API_BASE_URL || '').toString();
+        if (envProvider === 'ollama' && ollamaBase) {
+          setIsModelLoading('Ollama');
+          fetch('/api/models/Ollama')
+            .then((r) => r.json())
+            .then((data) => {
+              const typed = data as { modelList: ModelInfo[] };
+              setModelList((prev) => {
+                const other = prev.filter((m) => m.provider !== 'Ollama');
+                return [...other, ...typed.modelList];
+              });
+            })
+            .catch((e) => console.warn('Failed to prefetch Ollama models', e))
+            .finally(() => setIsModelLoading(undefined));
+        }
       }
-    }, []);
+    }, [providerList, provider]);
 
     const handleModelChange = (newModel: string) => {
       setModel(newModel);
@@ -711,6 +766,8 @@ export const ChatImpl = memo(
         selectedElement={selectedElement}
         setSelectedElement={setSelectedElement}
         addToolResult={addToolResult}
+        modelList={modelList}
+        isModelLoading={isModelLoading}
       />
     );
   },

--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -119,7 +119,7 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
               />
               {(props.providerList || []).length > 0 &&
                 props.provider &&
-                (!LOCAL_PROVIDERS.includes(props.provider.name) || 'OpenAILike') && (
+                (props.provider.name !== 'Ollama' && props.provider.name !== 'LMStudio' && props.provider.name !== 'OpenAILike') && (
                   <APIKeyManager
                     provider={props.provider}
                     apiKey={props.apiKeys[props.provider.name] || ''}

--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -92,7 +92,6 @@ export const ModelSelector = ({
     });
 
   const filteredProviders = providerList
-    .filter((p) => !['Ollama', 'LMStudio', 'OpenAILike', 'OfflineAI', 'Local'].includes(p.name))
     .filter((p) => p.name.toLowerCase().includes(providerSearchQuery.toLowerCase()));
 
   // Reset free models filter when provider changes

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -71,6 +71,30 @@ const getInitialProviderSettings = (): ProviderSetting => {
     };
   });
 
+  // If env prefers a specific provider, enable it
+  const envPreferred = (import.meta.env?.LLM_PROVIDER || '').toString().toLowerCase();
+  if (envPreferred) {
+    Object.keys(initialSettings).forEach((name) => {
+      initialSettings[name].settings = {
+        ...initialSettings[name].settings,
+        enabled: name.toLowerCase() === envPreferred || initialSettings[name].settings.enabled,
+      };
+    });
+  }
+
+  // Seed Ollama base URL and enable if provided by env
+  const ollamaBase = (import.meta.env?.OLLAMA_API_BASE_URL || '').toString();
+  if (ollamaBase) {
+    const key = 'Ollama';
+    if (initialSettings[key]) {
+      initialSettings[key].settings = {
+        ...initialSettings[key].settings,
+        baseUrl: ollamaBase,
+        enabled: true,
+      };
+    }
+  }
+
   // Only try to load from localStorage in the browser
   if (isBrowser) {
     const savedSettings = localStorage.getItem(PROVIDER_SETTINGS_KEY);

--- a/app/routes/api.models.ts
+++ b/app/routes/api.models.ts
@@ -17,7 +17,7 @@ interface ModelsResponse {
 let cachedProviders: UIProviderInfo[] | null = null;
 let cachedDefaultProvider: UIProviderInfo | null = null;
 
-function getProviderInfo(llmManager: LLMManager) {
+function getProviderInfo(llmManager: LLMManager, env?: Record<string, string>) {
   if (!cachedProviders) {
     cachedProviders = llmManager.getAllProviders().map((provider) => ({
       name: provider.name,
@@ -28,8 +28,12 @@ function getProviderInfo(llmManager: LLMManager) {
     }));
   }
 
+  const envPreferred = (env?.LLM_PROVIDER || '').toString().toLowerCase();
+
   if (!cachedDefaultProvider) {
-    const defaultProvider = llmManager.getDefaultProvider();
+    const defaultProvider = envPreferred
+      ? llmManager.getAllProviders().find((p) => p.name.toLowerCase() === envPreferred) || llmManager.getDefaultProvider()
+      : llmManager.getDefaultProvider();
     cachedDefaultProvider = {
       name: defaultProvider.name,
       staticModels: defaultProvider.staticModels,
@@ -62,7 +66,7 @@ export async function loader({
   const apiKeys = getApiKeysFromCookie(cookieHeader);
   const providerSettings = getProviderSettingsFromCookie(cookieHeader);
 
-  const { providers, defaultProvider } = getProviderInfo(llmManager);
+  const { providers, defaultProvider } = getProviderInfo(llmManager, context.cloudflare?.env);
 
   let modelList: ModelInfo[] = [];
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,6 +101,8 @@ export default defineConfig((config) => {
       'OLLAMA_API_BASE_URL',
       'LMSTUDIO_API_BASE_URL',
       'TOGETHER_API_BASE_URL',
+      'LLM_PROVIDER',
+      'OLLAMA_MODEL',
     ],
     css: {
       preprocessorOptions: {


### PR DESCRIPTION
Enable Ollama provider selection and configuration via environment variables and UI.

The UI previously ignored `LLM_PROVIDER` and `OLLAMA_MODEL` environment variables, causing a disconnect where Ollama was registered on the backend but not automatically selected or visible in the frontend provider dropdown. This PR ensures the UI respects these environment variables for initial setup and allows proper selection and configuration of local providers like Ollama.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa39398f-9d27-4f93-aea8-027efea98774">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa39398f-9d27-4f93-aea8-027efea98774">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable seamless Ollama self-host setup: the UI now honors LLM_PROVIDER, OLLAMA_MODEL, and OLLAMA_API_BASE_URL to auto-select the provider/model and use the correct local API URL.

- New Features
  - Initial provider/model now read from env (LLM_PROVIDER, OLLAMA_MODEL); Ollama is auto-selected when set.
  - Ollama base URL is respected in the UI (tags/pull/delete) and seeded from OLLAMA_API_BASE_URL.
  - Provider settings auto-enable the env-selected provider and Ollama when a base URL is provided.
  - Model lists load on startup; Ollama models are prefetched when Ollama is chosen via env.
  - API /api/models picks the default provider from env; hides API key UI for local providers; shows local providers in the model selector.
  - Vite exposes LLM_PROVIDER and OLLAMA_MODEL for client-side use.

- Migration
  - Set env: LLM_PROVIDER=Ollama, OLLAMA_MODEL=<model>, OLLAMA_API_BASE_URL=http://127.0.0.1:11434.
  - Clear selectedProvider and selectedModel cookies if you want env defaults to apply for existing users.
  - Restart the app.

<!-- End of auto-generated description by cubic. -->

---

🔧 This PR enables seamless Ollama self-hosted LLM configuration by making the UI respect environment variables for provider selection, model defaults, and API base URLs. It bridges the gap between backend Ollama registration and frontend visibility, allowing users to configure their local Ollama setup through environment variables rather than manual UI configuration.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Environment Variable Integration**: Added support for `LLM_PROVIDER`, `OLLAMA_MODEL`, and `OLLAMA_API_BASE_URL` environment variables to automatically configure the UI
- **Dynamic API URL Resolution**: Replaced hardcoded `http://127.0.0.1:11434` URLs with configurable base URLs that respect provider settings and environment variables
- **Provider Auto-Selection**: Modified initial provider and model selection logic to prioritize environment variables over default values
- **Local Provider Visibility**: Removed filters that hid local providers (Ollama, LMStudio, OpenAILike) from the model selector dropdown
- **Automatic Model Loading**: Added proactive fetching of Ollama models when the provider is configured via environment variables

### Technical Implementation
```mermaid
flowchart TD
    A[App Startup] --> B{Check Environment Variables}
    B -->|LLM_PROVIDER=ollama| C[Auto-select Ollama Provider]
    B -->|OLLAMA_MODEL set| D[Set Default Model]
    B -->|OLLAMA_API_BASE_URL set| E[Configure Base URL]
    
    C --> F[Enable Ollama in Settings]
    D --> G[Update Model Selection]
    E --> H[Update API Endpoints]
    
    F --> I[Prefetch Ollama Models]
    G --> I
    H --> I
    
    I --> J[Update UI State]
    J --> K[Ready for Use]
    
    L[API Calls] --> M{Determine Base URL}
    M -->|Provider Settings| N[Use Provider Base URL]
    M -->|Environment Variable| O[Use OLLAMA_API_BASE_URL]
    M -->|Fallback| P[Use Default OLLAMA_API_URL]
```

### Impact
- **Simplified Setup**: Users can now configure Ollama entirely through environment variables without manual UI configuration
- **Better Self-Hosting Support**: Eliminates the disconnect between backend provider registration and frontend visibility for local providers
- **Flexible Configuration**: Supports custom Ollama API URLs for different deployment scenarios (Docker, remote instances, custom ports)
- **Improved User Experience**: Local providers are now visible in the model selector, and API key management is appropriately hidden for local providers
- **Backward Compatibility**: Existing configurations continue to work while new environment-based setup is optional

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configurable Ollama server URL via settings or environment; auto-enables when provided.
  - Environment-driven defaults: select default provider (LLM_PROVIDER) and model (OLLAMA_MODEL).
  - Dynamic model loading per provider; chat shows available models and loading state.
  - Enhanced messaging: supports file attachments, embeds selected elements, and improves textarea resizing.

- Bug Fixes
  - Corrected API key manager visibility for local providers.
  - Provider search now includes previously excluded local providers.

- Chores
  - Exposed LLM_PROVIDER and OLLAMA_MODEL to the client via build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->